### PR TITLE
fix/filter-prompts+datasource-by-code-tag

### DIFF
--- a/packages/ui/src/components/ChatBox/ActionButtons.jsx
+++ b/packages/ui/src/components/ChatBox/ActionButtons.jsx
@@ -4,19 +4,23 @@ import AutoScrollToggle from './AutoScrollToggle';
 import {
   ActionButton
 } from './StyledComponents';
+import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 
 export default function ActionButtons({
   isStreaming,
   onStopAll,
+  onRefresh,
 }) {
   return (
     <>
+      <StyledTooltip title={'Reload Alita Code settings, prompt and datasource options'} placement="top">
+        <ActionButton onClick={onRefresh}>
+          <RefreshOutlinedIcon sx={{ fontSize: '1.13rem' }} color="icon" />
+        </ActionButton>
+      </StyledTooltip>
       {isStreaming &&
         <StyledTooltip title={'Stop generating'} placement="top">
-          <ActionButton
-            sx={{ height: '28px', width: '28px' }}
-            onClick={onStopAll}
-          >
+          <ActionButton onClick={onStopAll}>
             <StopCircleOutlinedIcon sx={{ fontSize: '1.13rem' }} color="icon" />
           </ActionButton>
         </StyledTooltip>}

--- a/packages/ui/src/components/ChatBox/ChatBox.jsx
+++ b/packages/ui/src/components/ChatBox/ChatBox.jsx
@@ -72,6 +72,7 @@ const ChatBox = forwardRef(({
     postMessageToVsCode,
     chatHistory = [],
     setChatHistory = () => { },
+    loadCoreData,
   } = useContext(DataContext);
   const chatInput = useRef(null);
   const listRefs = useRef([]);
@@ -369,12 +370,12 @@ const ChatBox = forwardRef(({
             <ActionButtons
               isStreaming={isStreaming}
               onStopAll={onStopAll}
+              onRefresh={loadCoreData}
             />
             <ActionButton
               aria-label="clear the chat"
               disabled={isLoading || isStreaming || !chatHistory.length}
               onClick={onClickClearChat}
-              sx={{ height: '28px', width: '28px' }}
             >
               <ClearIcon sx={{ fontSize: 16 }} />
             </ActionButton>

--- a/packages/ui/src/components/ChatBox/ChatInput.jsx
+++ b/packages/ui/src/components/ChatBox/ChatInput.jsx
@@ -144,9 +144,14 @@ const ChatInput = forwardRef(function ChatInput(props, ref) {
         const filterString = value.substring(1).toLowerCase()
         const options = isPrompt ? prompts : datasources
         const optionList = options.filter((item) => item.name.toLowerCase().startsWith(filterString))
-        setFilteredOptions(optionList.length ? optionList : options)
-        setChatWith(isPrompt ? ChatTypes.prompt : ChatTypes.datasource)
-        setAnchorEl(chatInputRef.current)
+        if (optionList.length < 1) {
+          // eslint-disable-next-line no-console
+          console.log(`No ${isPrompt ? 'prompt' : 'datasource'}options available`)
+        } else {
+          setFilteredOptions(optionList.length ? optionList : options)
+          setChatWith(isPrompt ? ChatTypes.prompt : ChatTypes.datasource)
+          setAnchorEl(chatInputRef.current)
+        }
       } else {
         setAnchorEl(null);
         setFilteredOptions([]);

--- a/packages/ui/src/components/ChatBox/StyledComponents.jsx
+++ b/packages/ui/src/components/ChatBox/StyledComponents.jsx
@@ -49,8 +49,8 @@ export const ActionContainer = styled(Box)(() => ({
 }));
 
 export const ActionButton = styled(IconButton)(({ theme }) => (`
-  width: 2rem;
-  height: 2rem;
+  height: 28px; 
+  width: 28px;
   display: flex;
   padding: 0.375rem;
   align-items: center;


### PR DESCRIPTION
1. filter by tag
2. add "reload settings" icon to reload core data such as alita code settings and prompt+datasource options