### PR TITLE
fix:  prompt variables state should be refreshed when switching between prompts

### DIFF
--- a/packages/ui/src/components/ChatBox/ChatInput.jsx
+++ b/packages/ui/src/components/ChatBox/ChatInput.jsx
@@ -76,6 +76,7 @@ const ChatInput = forwardRef(function ChatInput(props, ref) {
   const handleSelectOption = useCallback((option) => () => {
     setSelectedOption(option);
     getParticipantDetail(option);
+    setVariables([]);
     reset();
   }, [reset, getParticipantDetail]);
 


### PR DESCRIPTION
fix:  prompt variables state should be refreshed when switching between prompts