### PR TITLE
fix: support host url with segments for socket connection

### DIFF
--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -25,6 +25,7 @@ export const UiMessageTypes = {
   getDatasourceDetail: 'ui.getDatasourceDetail',
   getDatasources: 'ui.getDatasources',
   getChatResponse: 'ui.getChatResponse',
+  getProviderConfig:  'ui.getProviderConfig',
   getSocketConfig: 'ui.getSocketConfig',
   getModelSettings: 'ui.getModelSettings',
   getApplicationDetail: 'ui.getApplicationDetail',

--- a/packages/ui/src/context/SocketProvider.jsx
+++ b/packages/ui/src/context/SocketProvider.jsx
@@ -5,16 +5,16 @@ import SocketContext from "./SocketContext";
 import DataContext from "./DataContext";
 
 export function SocketProvider({ children }) {
-  const { socketConfig } = useContext(DataContext);
+  const { providerConfig } = useContext(DataContext);
   const [socket, setSocket] = useState(null);
   const [connected, setConnected] = useState(false);
 
   const createSocket = useCallback(() => {
-    if (!socketConfig || !socketConfig.host) return;
-    const { host, path, token } = socketConfig
+    if (!providerConfig || !providerConfig.socketHost) return;
+    const { socketHost, socketPath, token } = providerConfig
 
-    const socketIo = io(host, {
-      path,
+    const socketIo = io(socketHost, {
+      path: socketPath,
       reconnectionDelayMax: 2000,
       extraHeaders: {'Authorization': `Bearer ${token}`}
     })
@@ -33,18 +33,18 @@ export function SocketProvider({ children }) {
     })
 
     return socketIo
-  }, [socketConfig]);
+  }, [providerConfig]);
 
   useEffect(() => {
-    console.log('socketConfig', socketConfig)
-    if (!socketConfig || socket) return;
+    console.log('create socket with providerConfig', providerConfig)
+    if (!providerConfig || socket) return;
     const socketIo = createSocket()
     setSocket(socketIo)
 
     return () => {
       socketIo && socketIo.disconnect();
     };
-  }, [createSocket, socket, socketConfig]);
+  }, [createSocket, socket, providerConfig]);
 
   return (
     <SocketContext.Provider

--- a/packages/ui/src/pages/Prompts/Components/Form/VariableList.jsx
+++ b/packages/ui/src/pages/Prompts/Components/Form/VariableList.jsx
@@ -65,13 +65,13 @@ const VariableList = ({variables, onChangeVariable, ...props}) => {
 
   return (
     <div>
-      {variables.map(({ key, name, value }) => {
+      {variables.map(({ id, name, value }) => {
         return (
           <Variable
             onChangeVariable={onChangeVariable}
-            key={key || name}
-            label={key || name}
-            id={key || name}
+            key={id}
+            label={name}
+            id={name}
             value={value}
             isFirstRender={isFirstRender.current}
             {...props}

--- a/packages/ui/test/plugin/readme.md
+++ b/packages/ui/test/plugin/readme.md
@@ -36,6 +36,7 @@ Parameter --env serves to pass host of plugin server. Default value is http://ca
 By default, react chat UI is available to interact by http://localhost:8080/
 Use option --port to specify another port (_npx webpack serve --mode development --port 1234 ..._)
 
-Now you need to run javascript debug on webpack port (default is 8080) from IDE.
-VS Code: https://code.visualstudio.com/docs/nodejs/reactjs-tutorial#_debugging-react
+#### Debug
+You need run javascript debug configuration from your IDE on webpack port (default is 8080).  
+VS Code: https://code.visualstudio.com/docs/nodejs/reactjs-tutorial#_debugging-react  
 WebStorm: https://www.jetbrains.com/help/webstorm/react.html#react_debug_via_js_debug_rc

--- a/packages/ui/test/plugin/server.js
+++ b/packages/ui/test/plugin/server.js
@@ -54,7 +54,7 @@ app.get('/', async (req, res) => {
             case 'extension.getSocketConfig':
                 data = {
                     projectId,
-                    host,
+                    host: host.replace('http', 'ws'),
                     token,
                     path: '/socket.io'
                 }


### PR DESCRIPTION
Two fixes for react chat:

1. support Alita provider host url with path
there is an issue with chat if alita host has path like https://hostname.io/main.
socket.io requires provide hostname and path separately.

2. version variables populating when change prompt's version