### PR TITLE
fix: resetSocket to init connection with new settings

### DIFF
--- a/packages/ui/src/components/ChatBox/ChatBox.jsx
+++ b/packages/ui/src/components/ChatBox/ChatBox.jsx
@@ -302,7 +302,7 @@ const ChatBox = forwardRef(({
   }, [getMessage, handleError, scrollToMessageListEnd, setChatHistory])
 
   const dataContext = useContext(DataContext);
-  const { emit } = useSocket(
+  const { emit, resetSocket } = useSocket(
     chatWith === ChatTypes.datasource ?
       sioEvents.datasource_predict :
       chatWith === ChatTypes.application ?
@@ -502,7 +502,10 @@ const ChatBox = forwardRef(({
             <ActionButtons
               isStreaming={isStreaming}
               onStopAll={onStopAll}
-              onRefresh={loadCoreData}
+              onRefresh={() => {
+                resetSocket();
+                loadCoreData();
+              }}
             />
             <ActionButton
               aria-label="clear the chat"

--- a/packages/ui/src/context/SocketContext.jsx
+++ b/packages/ui/src/context/SocketContext.jsx
@@ -2,10 +2,9 @@ import { createContext } from 'react';
 
 const SocketContext = createContext({
   socket: null,
-  createSocket: () => {
-  },
-  disconnectSocket: () => {
-  }
+  createSocket: () => {},
+  disconnectSocket: () => {},
+  resetSocket: () => {},
 });
 
 export default SocketContext;

--- a/packages/ui/src/context/SocketProvider.jsx
+++ b/packages/ui/src/context/SocketProvider.jsx
@@ -35,6 +35,14 @@ export function SocketProvider({ children }) {
     return socketIo
   }, [providerConfig]);
 
+  const resetSocket = () => {
+    console.log("resetting socket");
+    socket.disconnect();
+
+    const socketIo = createSocket();
+    setSocket(socketIo);
+  };
+
   useEffect(() => {
     console.log('create socket with providerConfig', providerConfig)
     if (!providerConfig || socket) return;
@@ -52,6 +60,7 @@ export function SocketProvider({ children }) {
         socket,
         createSocket,
         connected,
+        resetSocket,
       }}
     >
       {children}

--- a/packages/ui/src/hooks/useSocket.jsx
+++ b/packages/ui/src/hooks/useSocket.jsx
@@ -2,7 +2,7 @@ import {useEffect, useCallback, useContext} from 'react';
 import SocketContext from '@/context/SocketContext';
 
 export const useManualSocket = (event, responseHandler) => {
-  const {socket, connected} = useContext(SocketContext);
+  const {socket, connected, resetSocket} = useContext(SocketContext);
   const reconnect = useCallback(() => {
     // eslint-disable-next-line no-console
     socket && socket.disconnected && console.log('reconnecting')
@@ -38,12 +38,13 @@ export const useManualSocket = (event, responseHandler) => {
     unsubscribe,
     emit,
     socket,
-    connected
+    connected,
+    resetSocket,
   }
 };
 
 const useSocket = (event, responseHandler) => {
-  const {subscribe, unsubscribe, emit, connected} = useManualSocket(event, responseHandler)
+  const {subscribe, unsubscribe, emit, connected, resetSocket} = useManualSocket(event, responseHandler)
 
   useEffect(() => {
     subscribe()
@@ -54,7 +55,8 @@ const useSocket = (event, responseHandler) => {
 
   return {
     emit,
-    connected
+    connected,
+    resetSocket,
   }
 };
 


### PR DESCRIPTION
Resolves an issue with socket connection after changing configuration settings in settings.json by adding `resetSocket` function which close a previous socket connection and initiate a new one.

## Recording with changing settings.json


https://github.com/user-attachments/assets/1ff80149-78ce-4a79-b659-2af0e70af1d6



